### PR TITLE
Fix crkbd 4.1 vial build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ vial-qmk-compile:
 	$(eval KB := ${kb})
 	$(eval KR := ${kr})
 	$(eval KM := ${km})
-	$(eval FILE := $(shell echo "${kb}_${kr}_${km}" | sed 's/\//_/'))
-	cd src/vial-kb/vial-qmk; qmk compile -kb tmp/${KB}/${KR} -km ${KM}
+	$(eval FILE := $(shell echo "${kb}_qmk_firmware_${kr}_${km}" | sed 's/\//_/'))
+	cd src/vial-kb/vial-qmk; qmk compile -kb tmp/${KB}/qmk_firmware/${KR} -km ${KM}
 	cp src/vial-kb/vial-qmk/.build/tmp_${FILE}.hex keyboards/${KB}/vial-kb/vial-qmk/.build/${FILE}.hex | true
 	cp src/vial-kb/vial-qmk/.build/tmp_${FILE}.uf2 keyboards/${KB}/vial-kb/vial-qmk/.build/${FILE}.uf2 | true
 

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Please change `kb`, `kr` and `km` when build other.
 ```sh
 make vial-qmk-clean
 kb=crkbd make vial-qmk-init
-kb=crkbd kr=rev4/standard km=vial make vial-qmk-compile
+kb=crkbd kr=rev4_1/standard km=vial make vial-qmk-compile
 ```
 A built data will be stored on `keyboards/crkbd/vial-kb/vial-qmk/.build`\
 Please change `kb`, `kr` and `km` when build other.


### PR DESCRIPTION
Fixing vial firmware build for corne v4.1. Tested with updated commands in the readme.md. This fixed #5 for me.